### PR TITLE
API Keys in Context, Artist Data Functions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,9 +12,12 @@ import {
     getPKCECodes,
     getTrack,
     getAlbum,
-    getArtwork
+    getAlbumArtwork,
+    getArtist,
+    getArtistImage,
+    getArtistAlbums
 } from "./lib/spotify/data";
-import { emptyAPIContextValue, Track, Album } from "./lib/spotify/types";
+import { emptyAPIContextValue, Track, Album, Artist } from "./lib/spotify/types";
 import AuthSuccessPage from "./AuthSuccessPage";
 import SpotifyContext from "./contexts/SpotifyContext";
 
@@ -26,6 +29,10 @@ export default function App() {
     const [currTrackImage, setCurrTrackImage] = useState<string | null>(null);
     const [currAlbumImage, setCurrAlbumImage] = useState<string | null>(null);
 
+    const [currArtist, setCurrArtist] = useState<Artist | null>(null);
+    const [currArtistImage, setCurrArtistImage] = useState<string | null>(null);
+    const [artistAlbums, setArtistAlbums] = useState<Array<Album> | null>(null);
+
     useEffect(() => {
         // these funcs are only called when accessToken is not null, we can force the value with !
         const trackWrapper = async () => {
@@ -35,7 +42,7 @@ export default function App() {
             );
             setCurrTrack(newTrack);
 
-            const newTrackImage = await getArtwork(
+            const newTrackImage = await getAlbumArtwork(
                 apiState.accessToken!,
                 newTrack.albumId
             );
@@ -49,16 +56,31 @@ export default function App() {
             );
             setCurrAlbum(newAlbum);
 
-            const newAlbumImage = await getArtwork(
+            const newAlbumImage = await getAlbumArtwork(
                 apiState.accessToken!,
                 "4HTy9WFTYooRjE9giTmzAF?si=efxmZtHvR1W8FKyo5r7_MQ"
             );
             setCurrAlbumImage(newAlbumImage);
         };
 
+        const artistWrapper = async () => {
+            const newArtist = await getArtist(apiState.accessToken!, "1oPRcJUkloHaRLYx0olBLJ");
+            setCurrArtist(newArtist);
+
+            const newArtistImage = await getArtistImage(apiState.accessToken!, "1oPRcJUkloHaRLYx0olBLJ");
+            setCurrArtistImage(newArtistImage);
+        };
+
+        const artistAlbumsWrapper = async () => {
+            const newAlbums = await getArtistAlbums(apiState.accessToken!, "1oPRcJUkloHaRLYx0olBLJ");
+            setArtistAlbums(newAlbums);
+        };
+
         if (apiState.accessToken !== null) {
             trackWrapper();
             albumWrapper();
+            artistWrapper();
+            artistAlbumsWrapper();
         }
     }, [apiState]);
 
@@ -83,6 +105,13 @@ export default function App() {
                             <p>Test album:</p>
                             <p>{JSON.stringify(currAlbum)}</p>
                             <img src={currAlbumImage ?? ""} />
+
+                            <p>Test artist:</p>
+                            <p>{JSON.stringify(currArtist)}</p>
+                            <img src={currArtistImage ?? ""} />
+
+                            <p>Test artist albums:</p>
+                            <p>{JSON.stringify(artistAlbums?.map((a) => a.name))}</p>
                         </div>
                     )}
                 </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,9 +16,11 @@ import {
 } from "./lib/spotify/data";
 import { emptyAPIContextValue, Track, Album } from "./lib/spotify/types";
 import AuthSuccessPage from "./AuthSuccessPage";
+import SpotifyContext from "./contexts/SpotifyContext";
 
 export default function App() {
     const [apiState, setApiState] = useState(emptyAPIContextValue());
+    
     const [currTrack, setCurrTrack] = useState<Track | null>(null);
     const [currAlbum, setCurrAlbum] = useState<Album | null>(null);
     const [currTrackImage, setCurrTrackImage] = useState<string | null>(null);
@@ -66,6 +68,10 @@ export default function App() {
             element: (
                 <>
                     <h1>Welcome!</h1>
+
+                    <p>API values:</p>
+                    <p>{JSON.stringify(apiState)}</p>
+
                     {apiState.accessToken === null ? (
                         <Link to="/auth">Authorize</Link>
                     ) : (
@@ -94,7 +100,7 @@ export default function App() {
         },
         {
             path: "/auth/success",
-            element: <AuthSuccessPage stateSetter={setApiState} />,
+            element: <AuthSuccessPage />,
             loader: async ({ request }) => {
                 const urlObj = new URL(request.url);
                 const codeVerifier = localStorage.getItem("codeVerifier");
@@ -107,5 +113,9 @@ export default function App() {
 
     const router = createBrowserRouter(routeObjects);
 
-    return <RouterProvider router={router} />;
+    return (
+        <SpotifyContext.Provider value={{ stateValue: apiState, stateSetter: setApiState }}>
+            <RouterProvider router={router} />
+        </SpotifyContext.Provider>
+    );
 }

--- a/src/AuthSuccessPage.tsx
+++ b/src/AuthSuccessPage.tsx
@@ -1,22 +1,21 @@
-import { useEffect } from "react";
+import { useEffect, useContext } from "react";
 import { useLoaderData } from "react-router-dom";
 import { APIContextValue } from "./lib/spotify/types";
 import { getUserAccessCode } from "./lib/spotify/data";
+import SpotifyContext from "./contexts/SpotifyContext";
 import { useNavigate } from "react-router-dom";
 
-export default function AuthSuccessPage({
-    stateSetter
-}: {
-    stateSetter: React.Dispatch<React.SetStateAction<APIContextValue>>;
-}) {
+export default function AuthSuccessPage() {
     const queryParams = useLoaderData() as URLSearchParams;
     const codeVerifier = queryParams.get("codeVerifier")!;
     const authorizationCode = queryParams.get("code")!;
     const navigate = useNavigate();
 
+    const { stateSetter } = useContext(SpotifyContext)!;
+
     useEffect(() => {
         const fetchWrapper = async () => {
-            const newState = await getUserAccessCode(
+            const newState: APIContextValue = await getUserAccessCode(
                 authorizationCode,
                 codeVerifier
             );

--- a/src/lib/spotify/data.ts
+++ b/src/lib/spotify/data.ts
@@ -107,6 +107,13 @@ export const getPKCECodes = async (length: number = 64) => {
     };
 };
 
+/**
+ * returns a new state value containing api keys for accessing the spotify api
+ * 
+ * @param authorizationCode code received from previous step
+ * @param codeVerifier codeVerifier generated from the start of the authorization flow
+ * @returns object containing all api keys and relevant info
+ */
 export const getUserAccessCode = async (
     authorizationCode: string,
     codeVerifier: string
@@ -144,6 +151,13 @@ export const getUserAccessCode = async (
     };
 };
 
+/**
+ * returns track data from the spotify api
+ * 
+ * @param accessToken needed to access spotify api
+ * @param trackId id of the track to be fetched
+ * @returns Track object
+ */
 export const getTrack = async (
     accessToken: string,
     trackId: string
@@ -168,6 +182,13 @@ export const getTrack = async (
     };
 };
 
+/**
+ * returns album data from the spotify api
+ * 
+ * @param accessToken needed to access spotify api
+ * @param trackId id of the album to be fetched
+ * @returns Album object
+ */
 export const getAlbum = async (
     accessToken: string,
     albumId: string
@@ -190,6 +211,13 @@ export const getAlbum = async (
     };
 };
 
+/**
+ * returns a temporary url, used to display artwork for a particular album
+ * 
+ * @param accessToken needed to access spotify api
+ * @param albumId id of album for which we want to fetch artwork
+ * @returns image url as string
+ */
 export const getArtwork = async (
     accessToken: string,
     albumId: string

--- a/src/lib/spotify/types.ts
+++ b/src/lib/spotify/types.ts
@@ -7,7 +7,7 @@ export type Track = {
     spotifyId: string;
     isrc: string;
     name: string;
-    artists: Array<string>;
+    artists: Array<{ name: string, spotifyId: string }>;
     platformURL: string;
     albumId: string;
 };
@@ -16,8 +16,15 @@ export type Album = {
     type: "album";
     spotifyId: string;
     name: string;
-    artists: Array<string>;
+    artists: Array<{ name: string, spotifyId: string }>;
     platformURL: string;
+};
+
+export type Artist = {
+    type: "artist",
+    spotifyId: string;
+    name: string;
+    platformURL: string
 };
 
 export type APIContextValue = {


### PR DESCRIPTION
- added `SpotifyContext` to be wrapped around the application router. allows api keys for Spotify data functions to be fetched from any component under `RouterProvider` by using `const { stateValue, stateSetter } = useContext(SpotifyContext)!;`
- added data functions for artist data (`getArtist`, `getArtistImage`, and `getArtistAlbums`)